### PR TITLE
Fix so peg can parse string with null bytes

### DIFF
--- a/bootstrap.peg.go
+++ b/bootstrap.peg.go
@@ -907,12 +907,10 @@ func (p *Peg) Init() {
 		tokenIndex++
 	}
 
+	length := len(buffer)
 	matchDot := func() bool {
-		if buffer[position] != END_SYMBOL {
-			position++
-			return true
-		}
-		return false
+		position++
+		return position < length
 	}
 
 	/*matchChar := func(c byte) bool {

--- a/peg.go
+++ b/peg.go
@@ -429,9 +429,10 @@ func (p *{{.StructName}}) Init() {
 	}
 
 	{{if .HasDot}}
+    length := len(buffer)
 	matchDot := func() bool {
 		position++
-		return position < len(buffer)
+		return position < length
 	}
 	{{end}}
 


### PR DESCRIPTION
With this change it is possible to parse strings that contain null bytes. This is possibly not compatible with other parsers.
