### PR TITLE
when computing line/symbol pairs, loop over rune array instead of string

### DIFF
--- a/bootstrap.peg.go
+++ b/bootstrap.peg.go
@@ -539,7 +539,7 @@ func translatePositions(buffer string, positions []int) textPositionMap {
 	sort.Ints(positions)
 
 search:
-	for i, c := range buffer[0:] {
+	for i, c := range []rune(buffer) {
 		if c == '\n' {
 			line, symbol = line+1, 0
 		} else {

--- a/peg.go
+++ b/peg.go
@@ -380,7 +380,7 @@ func translatePositions(buffer string, positions []int) textPositionMap {
 	length, translations, j, line, symbol := len(positions), make(textPositionMap, len(positions)), 0, 1, 0
 	sort.Ints(positions)
 
-	search: for i, c := range buffer[0:] {
+	search: for i, c := range []rune(buffer) {
 		if c == '\n' {line, symbol = line + 1, 0} else {symbol++}
 		if i == positions[j] {
 			translations[positions[j]] = textPosition{line, symbol}


### PR DESCRIPTION
In translatePositions(), the indexes in the `positions` slice are
rune indexes, not byte counts. However, when looping over `buffer[0:]`
the counter `i` will be a byte count so that when multibyte characters
are used,
- some rune indexes in the `positions` slice will never be matched in
  the inner loops
- line/symbol pairs will not match the correct numbers after a multi-
  byte character.
Looping over a rune slice fixes this issue.