### PR TITLE
Fix: _buffer declared and not used

### DIFF
--- a/peg.go
+++ b/peg.go
@@ -439,7 +439,7 @@ func (p *{{.StructName}}) Execute() {
 		{{end}}
 		}
 	}
-	_, _, _, _ = buffer, text, begin, end
+	_, _, _, _, _ = buffer, _buffer, text, begin, end
 }
 {{end}}
 


### PR DESCRIPTION
Fix error "_buffer declared and not used" if HasPush is false when running peg.