### PR TITLE
Fix golint warnings in generated code

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For an optional character match use:
 optional <- .?
 ```
 
-If specific charaters are to be matched use single quotes:
+If specific characters are to be matched use single quotes:
 ```
 specific <- 'a'* 'bc'+ 'de'?
 ```

--- a/bootstrap.peg.go
+++ b/bootstrap.peg.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 )
 
-const end_symbol rune = 1114112
+const endSymbol rune = 1114112
 
 /* The rule types inferred from the grammar are below. */
 type pegRule uint8
@@ -106,9 +106,9 @@ const (
 	ruleAction47
 	ruleAction48
 
-	rulePre_
-	rule_In_
-	rule_Suf
+	rulePre
+	ruleIn
+	ruleSuf
 )
 
 var rul3s = [...]string{
@@ -371,14 +371,14 @@ func (t *tokens32) PreOrder() (<-chan state32, [][]token32) {
 					if c, j := ordered[depth][i-1], depths[depth-1]; a.isParentOf(c) &&
 						(j < 2 || !ordered[depth-1][j-2].isParentOf(c)) {
 						if c.end != b.begin {
-							write(token32{pegRule: rule_In_, begin: c.end, end: b.begin}, true)
+							write(token32{pegRule: ruleIn, begin: c.end, end: b.begin}, true)
 						}
 						break
 					}
 				}
 
 				if a.begin < b.begin {
-					write(token32{pegRule: rulePre_, begin: a.begin, end: b.begin}, true)
+					write(token32{pegRule: rulePre, begin: a.begin, end: b.begin}, true)
 				}
 				break
 			}
@@ -399,7 +399,7 @@ func (t *tokens32) PreOrder() (<-chan state32, [][]token32) {
 					b = c
 					continue depthFirstSearch
 				} else if parent && b.end != a.end {
-					write(token32{pegRule: rule_Suf, begin: b.end, end: a.end}, true)
+					write(token32{pegRule: ruleSuf, begin: b.end, end: a.end}, true)
 				}
 
 				depth--
@@ -719,8 +719,8 @@ func (p *Peg) Execute() {
 
 func (p *Peg) Init() {
 	p.buffer = []rune(p.Buffer)
-	if len(p.buffer) == 0 || p.buffer[len(p.buffer)-1] != end_symbol {
-		p.buffer = append(p.buffer, end_symbol)
+	if len(p.buffer) == 0 || p.buffer[len(p.buffer)-1] != endSymbol {
+		p.buffer = append(p.buffer, endSymbol)
 	}
 
 	var tree tokenTree = &tokens32{tree: make([]token32, math.MaxInt16)}
@@ -757,7 +757,7 @@ func (p *Peg) Init() {
 	}
 
 	matchDot := func() bool {
-		if buffer[position] != end_symbol {
+		if buffer[position] != endSymbol {
 			position++
 			return true
 		}

--- a/peg.go
+++ b/peg.go
@@ -191,7 +191,7 @@ func (t *tokens{{.}}) PreOrder() (<-chan state{{.}}, [][]token{{.}}) {
 	s, ordered := make(chan state{{.}}, 6), t.Order()
 	go func() {
 		var states [8]state{{.}}
-		for i, _ := range states {
+		for i := range states {
 			states[i].depths = make([]int{{.}}, len(ordered))
 		}
 		depths, state, depth := make([]int{{.}}, len(ordered)), 0, 1
@@ -329,7 +329,7 @@ func (t *tokens{{.}}) Error() []token32 {
 	ordered := t.Order()
 	length := len(ordered)
 	tokens, length := make([]token32, length), length - 1
-	for i, _ := range tokens {
+	for i := range tokens {
 		o := ordered[length - i]
 		if len(o) > 1 {
 			tokens[i] = o[len(o) - 2].getToken32()

--- a/peg.go
+++ b/peg.go
@@ -80,8 +80,8 @@ func (node *node32) print(depth int, buffer string) {
 	}
 }
 
-func (ast *node32) Print(buffer string) {
-	ast.print(0, buffer)
+func (node *node32) Print(buffer string) {
+	node.print(0, buffer)
 }
 
 type element struct {

--- a/peg.go
+++ b/peg.go
@@ -7,7 +7,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"github.com/pointlander/jetset"
 	"go/parser"
 	"go/printer"
 	"go/token"
@@ -17,16 +16,18 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+
+	"github.com/pointlander/jetset"
 )
 
-const PEG_HEADER_TEMPLATE = `package {{.PackageName}}
+const pegHeaderTemplate = `package {{.PackageName}}
 
 import (
 	{{range .Imports}}"{{.}}"
 	{{end}}
 )
 
-const end_symbol rune = {{.EndSymbol}}
+const endSymbol rune = {{.EndSymbol}}
 
 /* The rule types inferred from the grammar are below. */
 type pegRule {{.PegRuleType}}
@@ -35,9 +36,9 @@ const (
 	ruleUnknown pegRule = iota
 	{{range .RuleNames}}rule{{.String}}
 	{{end}}
-	rulePre_
-	rule_In_
-	rule_Suf
+	rulePre
+	ruleIn
+	ruleSuf
 )
 
 var rul3s = [...]string {
@@ -211,14 +212,14 @@ func (t *tokens{{.}}) PreOrder() (<-chan state{{.}}, [][]token{{.}}) {
 					if c, j := ordered[depth][i - 1], depths[depth - 1]; a.isParentOf(c) &&
 						(j < 2 || !ordered[depth - 1][j - 2].isParentOf(c)) {
 						if c.end != b.begin {
-							write(token{{.}} {pegRule: rule_In_, begin: c.end, end: b.begin}, true)
+							write(token{{.}} {pegRule: ruleIn, begin: c.end, end: b.begin}, true)
 						}
 						break
 					}
 				}
 
 				if a.begin < b.begin {
-					write(token{{.}} {pegRule: rulePre_, begin: a.begin, end: b.begin}, true)
+					write(token{{.}} {pegRule: rulePre, begin: a.begin, end: b.begin}, true)
 				}
 				break
 			}
@@ -239,7 +240,7 @@ func (t *tokens{{.}}) PreOrder() (<-chan state{{.}}, [][]token{{.}}) {
 					b = c
 					continue depthFirstSearch
 				} else if parent && b.end != a.end {
-					write(token{{.}} {pegRule: rule_Suf, begin: b.end, end: a.end}, true)
+					write(token{{.}} {pegRule: ruleSuf, begin: b.end, end: a.end}, true)
 				}
 
 				depth--
@@ -451,8 +452,8 @@ func (p *{{.StructName}}) Execute() {
 
 func (p *{{.StructName}}) Init() {
 	p.buffer = []rune(p.Buffer)
-	if len(p.buffer) == 0 || p.buffer[len(p.buffer) - 1] != end_symbol {
-		p.buffer = append(p.buffer, end_symbol)
+	if len(p.buffer) == 0 || p.buffer[len(p.buffer) - 1] != endSymbol {
+		p.buffer = append(p.buffer, endSymbol)
 	}
 
 	var tree tokenTree = &tokens32{tree: make([]token32, math.MaxInt16)}
@@ -490,7 +491,7 @@ func (p *{{.StructName}}) Init() {
 
 	{{if .HasDot}}
 	matchDot := func() bool {
-		if buffer[position] != end_symbol {
+		if buffer[position] != endSymbol {
 			position++
 			return true
 		}
@@ -1371,7 +1372,7 @@ func (t *Tree) Compile(file string, out io.Writer) {
 			fmt.Fprintf(os.Stderr, "internal error #1 (%v)\n", n)
 		case TypeDot:
 			_print("\n   if !matchDot() {")
-			/*print("\n   if buffer[position] == end_symbol {")*/
+			/*print("\n   if buffer[position] == endSymbol {")*/
 			printJump(ko)
 			/*print("}\nposition++")*/
 			_print("}")
@@ -1574,7 +1575,7 @@ func (t *Tree) Compile(file string, out io.Writer) {
 	} else if length > math.MaxUint8 {
 		t.PegRuleType = "uint16"
 	}
-	printTemplate(PEG_HEADER_TEMPLATE)
+	printTemplate(pegHeaderTemplate)
 	for _, element := range t.Slice() {
 		if element.GetType() != TypeRule {
 			continue


### PR DESCRIPTION
These commits fixes golint warnings I got for the code generated by peg. Closes #48.

Before: 
```
configfile.peg.go:10:7: don't use underscores in Go names; const end_symbol should be endSymbol
configfile.peg.go:29:2: don't use underscores in Go names; const rule_ should be rule
configfile.peg.go:38:2: don't use underscores in Go names; const rulePre_ should be rulePre
configfile.peg.go:39:2: don't use underscores in Go names; const rule_In_ should be ruleIn
configfile.peg.go:40:2: don't use underscores in Go names; const rule_Suf should be ruleSuf
configfile.peg.go:101:1: receiver name ast should be consistent with previous receiver name node for node32
configfile.peg.go:210:10: should omit 2nd value from range; this loop is equivalent to `for i := range ...`
configfile.peg.go:349:9: should omit 2nd value from range; this loop is equivalent to `for i := range ...`
```