### PR TITLE
New option -noast to generate parser w/out AST support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,6 @@ bootstrap.peg.go: bootstrap/main.go peg.go
 
 clean:
 	rm -f bootstrap/bootstrap peg peg.peg.go
+
+test:
+	go test -benchmem -bench .

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ bootstrap.peg.go: bootstrap/main.go peg.go
 	cd bootstrap; go build
 	bootstrap/bootstrap
 
+.PHONY:clean
 clean:
 	rm -f bootstrap/bootstrap peg peg.peg.go
 
-test:
+.PHONY:test
+test: bootstrap.peg.go
+	go test
 	go test -benchmem -bench .

--- a/Makefile
+++ b/Makefile
@@ -16,4 +16,7 @@ clean:
 .PHONY:test
 test: bootstrap.peg.go
 	go test
+
+.PHONY:bench
+bench:
 	go test -benchmem -bench .

--- a/bootstrap.peg.go
+++ b/bootstrap.peg.go
@@ -513,7 +513,8 @@ func (p *Peg) Init() {
 	}
 	p.reset()
 
-	_rules, tree := p.rules, tokens32{tree: make([]token32, math.MaxInt16)}
+	_rules := p.rules
+	tree := tokens32{tree: make([]token32, math.MaxInt16)}
 	p.parse = func(rule ...int) error {
 		r := 1
 		if len(rule) > 0 {

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -12,7 +12,7 @@ import (
 
 func main() {
 	runtime.GOMAXPROCS(2)
-	t := New(true, true)
+	t := New(true, true, false)
 
 	/*package main
 

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var (
 	_switch = flag.Bool("switch", false, "replace if-else if-else like blocks with switch blocks")
 	print   = flag.Bool("print", false, "directly dump the syntax tree")
 	syntax  = flag.Bool("syntax", false, "print out the syntax tree")
+	noast   = flag.Bool("noast", false, "disable AST")
 )
 
 func main() {
@@ -35,7 +36,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	p := &Peg{Tree: New(*inline, *_switch), Buffer: string(buffer), Pretty: true}
+	p := &Peg{Tree: New(*inline, *_switch, *noast), Buffer: string(buffer), Pretty: true}
 	p.Init()
 	if err := p.Parse(); err != nil {
 		log.Fatal(err)

--- a/peg.go
+++ b/peg.go
@@ -147,7 +147,7 @@ type {{.StructName}} struct {
 	Pretty 	bool
 {{if .Ast -}}
 	tokens32
-{{- end}}
+{{end -}}
 }
 
 func (p *{{.StructName}}) Parse(rule ...int) error {
@@ -241,7 +241,7 @@ func (p *{{.StructName}}) Init() {
 		buffer []rune
 {{if not .Ast -}}
 		text string
-{{- end}}
+{{end -}}
 	)
 	p.reset = func() {
 		max = token32{}
@@ -258,7 +258,7 @@ func (p *{{.StructName}}) Init() {
 	_rules := p.rules
 {{if .Ast -}}
 	tree := tokens32{tree: make([]token32, math.MaxInt16)}
-{{- end}}
+{{end -}}
 	p.parse = func(rule ...int) error {
 		r := 1
 		if len(rule) > 0 {
@@ -267,11 +267,11 @@ func (p *{{.StructName}}) Init() {
 		matches := p.rules[r]()
 {{if .Ast -}}
 		p.tokens32 = tree
-{{- end}}
+{{end -}}
 		if matches {
 {{if .Ast -}}
 			p.Trim(tokenIndex)
-{{- end}}
+{{end -}}
 			return nil
 		}
 		return &parseError{p, max}
@@ -280,7 +280,7 @@ func (p *{{.StructName}}) Init() {
 	add := func(rule pegRule, begin uint32) {
 {{if .Ast -}}
 		tree.Add(rule, begin, position, tokenIndex)
-{{- end}}
+{{end -}}
 		tokenIndex++
 		if begin != position && position > max.end {
 			max = token32{rule, begin, position}

--- a/peg.go
+++ b/peg.go
@@ -53,6 +53,7 @@ func (t *token32) String() string {
 	return fmt.Sprintf("\x1B[34m%v\x1B[m %v %v", rul3s[t.pegRule], t.begin, t.end)
 }
 
+{{if .Ast}}
 type node32 struct {
 	token32
 	up, next *node32
@@ -134,6 +135,7 @@ func (t *tokens32) Add(rule pegRule, begin, end, index uint32) {
 func (t *tokens32) Tokens() []token32 {
 	return t.tree
 }
+{{end}}
 
 type {{.StructName}} struct {
 	{{.StructVariables}}
@@ -143,7 +145,7 @@ type {{.StructName}} struct {
 	parse		func(rule ...int) error
 	reset		func()
 	Pretty 	bool
-	tokens32
+{{if .Ast}}    tokens32{{end}}
 }
 
 func (p *{{.StructName}}) Parse(rule ...int) error {
@@ -205,6 +207,7 @@ func (e *parseError) Error() string {
 	return error
 }
 
+{{if .Ast}}
 func (p *{{.StructName}}) PrintSyntaxTree() {
 	p.tokens32.PrintSyntaxTree(p.Buffer)
 }
@@ -227,6 +230,7 @@ func (p *{{.StructName}}) Execute() {
 	_, _, _, _, _ = buffer, _buffer, text, begin, end
 }
 {{end}}
+{{end}}
 
 func (p *{{.StructName}}) Init() {
 	var (
@@ -246,23 +250,24 @@ func (p *{{.StructName}}) Init() {
 	}
 	p.reset()
 
-	_rules, tree := p.rules, tokens32{tree: make([]token32, math.MaxInt16)}
+    _rules := p.rules
+{{if .Ast}} tree := tokens32{tree: make([]token32, math.MaxInt16)}{{end}}
 	p.parse = func(rule ...int) error {
 		r := 1
 		if len(rule) > 0 {
 			r = rule[0]
 		}
 		matches := p.rules[r]()
-		p.tokens32 = tree
+{{if .Ast}}     p.tokens32 = tree{{end}}
 		if matches {
-			p.Trim(tokenIndex)
+{{if .Ast}}         p.Trim(tokenIndex){{end}}
 			return nil
 		}
 		return &parseError{p, max}
 	}
 
 	add := func(rule pegRule, begin uint32) {
-		tree.Add(rule, begin, position, tokenIndex)
+{{if .Ast}} tree.Add(rule, begin, position, tokenIndex){{end}}
 		tokenIndex++
 		if begin != position && position > max.end {
 			max = token32{rule, begin, position}
@@ -520,7 +525,7 @@ type Tree struct {
 	Rules      map[string]Node
 	rulesCount map[string]uint
 	node
-	inline, _switch bool
+	inline, _switch, Ast bool
 
 	RuleNames       []Node
 	PackageName     string
@@ -541,11 +546,12 @@ type Tree struct {
 	HasRange        bool
 }
 
-func New(inline, _switch bool) *Tree {
+func New(inline, _switch, noast bool) *Tree {
 	return &Tree{Rules: make(map[string]Node),
 		rulesCount: make(map[string]uint),
 		inline:     inline,
-		_switch:    _switch}
+		_switch:    _switch,
+		Ast:        !noast}
 }
 
 func (t *Tree) AddRule(name string) {
@@ -662,7 +668,9 @@ func escape(c string) string {
 
 func (t *Tree) Compile(file string, out io.Writer) {
 	t.AddImport("fmt")
-	t.AddImport("math")
+	if t.Ast {
+		t.AddImport("math")
+	}
 	t.AddImport("sort")
 	t.AddImport("strconv")
 	t.EndSymbol = 0x110000

--- a/peg_test.go
+++ b/peg_test.go
@@ -11,7 +11,7 @@ func TestCorrect(t *testing.T) {
 type T Peg {}
 Grammar <- !.
 `
-	p := &Peg{Tree: New(false, false), Buffer: buffer}
+	p := &Peg{Tree: New(false, false, false), Buffer: buffer}
 	p.Init()
 	err := p.Parse()
 	if err != nil {
@@ -24,7 +24,7 @@ func TestNoSpacePackage(t *testing.T) {
 type T Peg {}
 Grammar <- !.
 `
-	p := &Peg{Tree: New(false, false), Buffer: buffer}
+	p := &Peg{Tree: New(false, false, false), Buffer: buffer}
 	p.Init()
 	err := p.Parse()
 	if err == nil {
@@ -38,7 +38,7 @@ package p
 typenospace Peg {}
 Grammar <- !.
 `
-	p := &Peg{Tree: New(false, false), Buffer: buffer}
+	p := &Peg{Tree: New(false, false, false), Buffer: buffer}
 	p.Init()
 	err := p.Parse()
 	if err == nil {
@@ -52,9 +52,9 @@ func TestSame(t *testing.T) {
 		t.Error(err)
 	}
 
-	p := &Peg{Tree: New(true, true), Buffer: string(buffer)}
+	p := &Peg{Tree: New(true, true, false), Buffer: string(buffer)}
 	p.Init()
-	if err := p.Parse(); err != nil {
+	if err = p.Parse(); err != nil {
 		t.Error(err)
 	}
 
@@ -81,14 +81,34 @@ func TestSame(t *testing.T) {
 	}
 }
 
-func BenchmarkParse(b *testing.B) {
-	files := [...]string{
-		"peg.peg",
-		"grammars/c/c.peg",
-		"grammars/calculator/calculator.peg",
-		"grammars/fexl/fexl.peg",
-		"grammars/java/java_1_7.peg",
+var files = [...]string{
+	"peg.peg",
+	"grammars/c/c.peg",
+	"grammars/calculator/calculator.peg",
+	"grammars/fexl/fexl.peg",
+	"grammars/java/java_1_7.peg",
+}
+
+func BenchmarkInitOnly(b *testing.B) {
+	pegs := []string{}
+	for _, file := range files {
+		input, err := ioutil.ReadFile(file)
+		if err != nil {
+			b.Error(err)
+		}
+		pegs = append(pegs, string(input))
 	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, peg := range pegs {
+			p := &Peg{Tree: New(true, true, false), Buffer: string(peg)}
+			p.Init()
+		}
+	}
+}
+
+func BenchmarkParse(b *testing.B) {
 	pegs := make([]*Peg, len(files))
 	for i, file := range files {
 		input, err := ioutil.ReadFile(file)
@@ -96,7 +116,33 @@ func BenchmarkParse(b *testing.B) {
 			b.Error(err)
 		}
 
-		p := &Peg{Tree: New(true, true), Buffer: string(input)}
+		p := &Peg{Tree: New(true, true, false), Buffer: string(input)}
+		p.Init()
+		pegs[i] = p
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, peg := range pegs {
+			b.StopTimer()
+			peg.Reset()
+			b.StartTimer()
+			if err := peg.Parse(); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkResetAndParse(b *testing.B) {
+	pegs := make([]*Peg, len(files))
+	for i, file := range files {
+		input, err := ioutil.ReadFile(file)
+		if err != nil {
+			b.Error(err)
+		}
+
+		p := &Peg{Tree: New(true, true, false), Buffer: string(input)}
 		p.Init()
 		pegs[i] = p
 	}
@@ -113,29 +159,44 @@ func BenchmarkParse(b *testing.B) {
 }
 
 func BenchmarkInitAndParse(b *testing.B) {
-	files := [...]string{
-		"peg.peg",
-		"grammars/c/c.peg",
-		"grammars/calculator/calculator.peg",
-		"grammars/fexl/fexl.peg",
-		"grammars/java/java_1_7.peg",
-	}
-	pegs := []string{}
+	strs := []string{}
 	for _, file := range files {
 		input, err := ioutil.ReadFile(file)
 		if err != nil {
 			b.Error(err)
 		}
-		pegs = append(pegs, string(input))
+		strs = append(strs, string(input))
 	}
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		for _, peg := range pegs {
-			p := &Peg{Tree: New(true, true), Buffer: string(peg)}
-			p.Init()
-			p.Reset()
-			if err := p.Parse(); err != nil {
+		for _, str := range strs {
+			peg := &Peg{Tree: New(true, true, false), Buffer: string(str)}
+			peg.Init()
+			if err := peg.Parse(); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}
+
+func BenchmarkInitResetAndParse(b *testing.B) {
+	strs := []string{}
+	for _, file := range files {
+		input, err := ioutil.ReadFile(file)
+		if err != nil {
+			b.Error(err)
+		}
+		strs = append(strs, string(input))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, str := range strs {
+			peg := &Peg{Tree: New(true, true, false), Buffer: string(str)}
+			peg.Init()
+			peg.Reset()
+			if err := peg.Parse(); err != nil {
 				b.Error(err)
 			}
 		}

--- a/peg_test.go
+++ b/peg_test.go
@@ -111,3 +111,33 @@ func BenchmarkParse(b *testing.B) {
 		}
 	}
 }
+
+func BenchmarkInitAndParse(b *testing.B) {
+	files := [...]string{
+		"peg.peg",
+		"grammars/c/c.peg",
+		"grammars/calculator/calculator.peg",
+		"grammars/fexl/fexl.peg",
+		"grammars/java/java_1_7.peg",
+	}
+	pegs := []string{}
+	for _, file := range files {
+		input, err := ioutil.ReadFile(file)
+		if err != nil {
+			b.Error(err)
+		}
+		pegs = append(pegs, string(input))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		for _, peg := range pegs {
+			p := &Peg{Tree: New(true, true), Buffer: string(peg)}
+			p.Init()
+			p.Reset()
+			if err := p.Parse(); err != nil {
+				b.Error(err)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implements #53 and improve #51.

Didn`t dare to check if peg itself could be made with such option. 

As per #51 benchcmp for extremely stupid grammar with actions (see at https://github.com/egorse/peg_ex)
```
benchmark           old ns/op     new ns/op     delta
Benchmark100-4      98626         6583          -93.33%
Benchmark200-4      106745        11241         -89.47%
Benchmark500-4      125213        25230         -79.85%
Benchmark1k-4       154281        50276         -67.41%
Benchmark10k-4      689338        482092        -30.06%
Benchmark20k-4      678916        483708        -28.75%
Benchmark50k-4      3255189       2337557       -28.19%
Benchmark100k-4     6744704       4654680       -30.99%
Benchmark200k-4     14254404      9987951       -29.93%
Benchmark500k-4     36308161      26848004      -26.06%
Benchmark1M-4       83490497      55150098      -33.94%

benchmark           old allocs     new allocs     delta
Benchmark100-4      61             60             -1.64%
Benchmark200-4      104            103            -0.96%
Benchmark500-4      231            230            -0.43%
Benchmark1k-4       456            455            -0.22%
Benchmark10k-4      4254           4253           -0.02%
Benchmark20k-4      4254           4253           -0.02%
Benchmark50k-4      21115          21113          -0.01%
Benchmark100k-4     42202          42199          -0.01%
Benchmark200k-4     84374          84370          -0.00%
Benchmark500k-4     210870         210864         -0.00%
Benchmark1M-4       431823         431816         -0.00%

benchmark           old bytes     new bytes     delta
Benchmark100-4      394752        1472          -99.63%
Benchmark200-4      395680        2400          -99.39%
Benchmark500-4      397920        4640          -98.83%
Benchmark1k-4       402528        9248          -97.70%
Benchmark10k-4      495136        101856        -79.43%
Benchmark20k-4      495136        101856        -79.43%
Benchmark50k-4      1669664       489952        -70.66%
Benchmark100k-4     3715745       963168        -74.08%
Benchmark200k-4     7938976       2040672       -74.30%
Benchmark500k-4     30062176      5289506       -82.40%
Benchmark1M-4       61947872      12009376      -80.61%
```
