### PR TITLE
Make Peg.PrintSyntaxTree respect Pretty flag

### DIFF
--- a/bootstrap.peg.go
+++ b/bootstrap.peg.go
@@ -216,14 +216,20 @@ type node32 struct {
 	up, next *node32
 }
 
-func (node *node32) Print(buffer string) {
+func (node *node32) print(pretty bool, buffer string) {
 	var print func(node *node32, depth int)
 	print = func(node *node32, depth int) {
 		for node != nil {
 			for c := 0; c < depth; c++ {
 				fmt.Printf(" ")
 			}
-			fmt.Printf("\x1B[34m%v\x1B[m %v\n", rul3s[node.pegRule], strconv.Quote(string(([]rune(buffer)[node.begin:node.end]))))
+			rule := rul3s[node.pegRule]
+			quote := strconv.Quote(string(([]rune(buffer)[node.begin:node.end])))
+			if !pretty {
+				fmt.Printf("%v %v\n", rule, quote)
+			} else {
+				fmt.Printf("\x1B[34m%v\x1B[m %v\n", rule, quote)
+			}
 			if node.up != nil {
 				print(node.up, depth+1)
 			}
@@ -231,6 +237,14 @@ func (node *node32) Print(buffer string) {
 		}
 	}
 	print(node, 0)
+}
+
+func (node *node32) Print(buffer string) {
+	node.print(false, buffer)
+}
+
+func (node *node32) PrettyPrint(buffer string) {
+	node.print(true, buffer)
 }
 
 type tokens32 struct {
@@ -274,6 +288,10 @@ func (t *tokens32) AST() *node32 {
 
 func (t *tokens32) PrintSyntaxTree(buffer string) {
 	t.AST().Print(buffer)
+}
+
+func (t *tokens32) PrettyPrintSyntaxTree(buffer string) {
+	t.AST().PrettyPrint(buffer)
 }
 
 func (t *tokens32) Add(rule pegRule, begin, end, index uint32) {
@@ -374,7 +392,11 @@ func (e *parseError) Error() string {
 }
 
 func (p *Peg) PrintSyntaxTree() {
-	p.tokens32.PrintSyntaxTree(p.Buffer)
+	if p.Pretty {
+		p.tokens32.PrettyPrintSyntaxTree(p.Buffer)
+	} else {
+		p.tokens32.PrintSyntaxTree(p.Buffer)
+	}
 }
 
 func (p *Peg) Execute() {

--- a/peg.go
+++ b/peg.go
@@ -66,6 +66,23 @@ func (node *node32) Print(buffer string) {
 			for c := 0; c < depth; c++ {
 				fmt.Printf(" ")
 			}
+			fmt.Printf("%v %v\n", rul3s[node.pegRule], strconv.Quote(string(([]rune(buffer)[node.begin:node.end]))))
+			if node.up != nil {
+				print(node.up, depth + 1)
+			}
+			node = node.next
+		}
+	}
+	print(node, 0)
+}
+
+func (node *node32) PrettyPrint(buffer string) {
+	var print func(node *node32, depth int)
+	print = func(node *node32, depth int) {
+		for node != nil {
+			for c := 0; c < depth; c++ {
+				fmt.Printf(" ")
+			}
 			fmt.Printf("\x1B[34m%v\x1B[m %v\n", rul3s[node.pegRule], strconv.Quote(string(([]rune(buffer)[node.begin:node.end]))))
 			if node.up != nil {
 				print(node.up, depth + 1)
@@ -117,6 +134,10 @@ func (t *tokens32) AST() *node32 {
 
 func (t *tokens32) PrintSyntaxTree(buffer string) {
 	t.AST().Print(buffer)
+}
+
+func (t *tokens32) PrettyPrintSyntaxTree(buffer string) {
+	t.AST().PrettyPrint(buffer)
 }
 
 func (t *tokens32) Add(rule pegRule, begin, end, index uint32) {
@@ -211,7 +232,11 @@ func (e *parseError) Error() string {
 
 {{if .Ast}}
 func (p *{{.StructName}}) PrintSyntaxTree() {
-	p.tokens32.PrintSyntaxTree(p.Buffer)
+	if p.Pretty {
+		p.tokens32.PrettyPrintSyntaxTree(p.Buffer)
+	} else {
+		p.tokens32.PrintSyntaxTree(p.Buffer)
+	}
 }
 
 {{if .HasActions}}

--- a/peg.go
+++ b/peg.go
@@ -59,14 +59,20 @@ type node32 struct {
 	up, next *node32
 }
 
-func (node *node32) Print(buffer string) {
+func (node *node32) print(pretty bool, buffer string) {
 	var print func(node *node32, depth int)
 	print = func(node *node32, depth int) {
 		for node != nil {
 			for c := 0; c < depth; c++ {
 				fmt.Printf(" ")
 			}
-			fmt.Printf("%v %v\n", rul3s[node.pegRule], strconv.Quote(string(([]rune(buffer)[node.begin:node.end]))))
+			rule := rul3s[node.pegRule]
+			quote := strconv.Quote(string(([]rune(buffer)[node.begin:node.end])))
+			if !pretty {
+				fmt.Printf("%v %v\n", rule, quote)
+			} else {
+				fmt.Printf("\x1B[34m%v\x1B[m %v\n", rule, quote)
+			}
 			if node.up != nil {
 				print(node.up, depth + 1)
 			}
@@ -76,21 +82,12 @@ func (node *node32) Print(buffer string) {
 	print(node, 0)
 }
 
+func (node *node32) Print(buffer string) {
+	node.print(false, buffer)
+}
+
 func (node *node32) PrettyPrint(buffer string) {
-	var print func(node *node32, depth int)
-	print = func(node *node32, depth int) {
-		for node != nil {
-			for c := 0; c < depth; c++ {
-				fmt.Printf(" ")
-			}
-			fmt.Printf("\x1B[34m%v\x1B[m %v\n", rul3s[node.pegRule], strconv.Quote(string(([]rune(buffer)[node.begin:node.end]))))
-			if node.up != nil {
-				print(node.up, depth + 1)
-			}
-			node = node.next
-		}
-	}
-	print(node, 0)
+	node.print(true, buffer)
 }
 
 type tokens32 struct {


### PR DESCRIPTION
More important (to me, at least) for dumb terminals / frontends where
escape codes don't work (i.e., automated builds and so on that have
test output dropped into a browser as preformatted text). Aside from
that, it'd be nice to have printing respect the Peg config in use.

To avoid breaking existing calls to Print and PrintSyntaxTree, new
forms of those methods with Pretty prefixed to them have been added
along with a *node32.print method that accepts a pretty flag to switch
between format strings.  This at least allows existing use of the Print
functions to work, even if it'll stop colorizing their output with
escapes unless Pretty is true in the Peg struct.

Includes a regenerated bootstrap.peg.go so tests pass.