### PR TITLE
Fixed unused variable where there is no string capture.

### DIFF
--- a/peg.go
+++ b/peg.go
@@ -240,7 +240,9 @@ func (p *{{.StructName}}) Init() {
 		position, tokenIndex uint32
 		buffer []rune
 {{if not .Ast -}}
+{{if .HasPush -}}
 		text string
+{{end -}}
 {{end -}}
 	)
 	p.reset = func() {


### PR DESCRIPTION
The switch -noast cause text variable being declared even if there is no capture exists.
This small patch fixes it.