### PR TITLE
Peg 67 pull of "simple" changes

### DIFF
--- a/grammars/c/Makefile
+++ b/grammars/c/Makefile
@@ -10,3 +10,6 @@ c.peg.go: c.peg
 
 clean:
 	rm -f c c.peg.go
+
+test:
+	go test

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -110,7 +110,7 @@ type C Peg {
 
 }
 
-TranslationUnit <- Spacing ExternalDeclaration+ EOT
+TranslationUnit <- Spacing ExternalDeclaration* EOT
 
 ExternalDeclaration <- FunctionDefinition / Declaration
 

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -177,7 +177,7 @@ StructOrUnionSpecifier
 
 StructOrUnion <- STRUCT / UNION
 
-StructDeclaration <- ( SpecifierQualifierList StructDeclaratorList )? SEMI
+StructDeclaration <- ( SpecifierQualifierList StructDeclaratorList? )? SEMI
 
 SpecifierQualifierList
    <- ( TypeQualifier*

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -608,7 +608,7 @@ Escape
     / HexEscape
     / UniversalCharacter
 
-SimpleEscape <- '\\' ['\"?\\abfnrtv]
+SimpleEscape <- '\\' ['\"?\\%abfnrtv]
 OctalEscape  <- '\\' [0-7][0-7]?[0-7]?
 HexEscape    <- '\\x' HexDigit+
 

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -110,7 +110,7 @@ type C Peg {
 
 }
 
-TranslationUnit <- Spacing ExternalDeclaration* EOT
+TranslationUnit <- Spacing ( ExternalDeclaration / SEMI ) * EOT
 
 ExternalDeclaration <- FunctionDefinition / Declaration
 

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -177,7 +177,7 @@ StructOrUnionSpecifier
 
 StructOrUnion <- STRUCT / UNION
 
-StructDeclaration <- SpecifierQualifierList StructDeclaratorList SEMI
+StructDeclaration <- ( SpecifierQualifierList StructDeclaratorList )? SEMI
 
 SpecifierQualifierList
    <- ( TypeQualifier*

--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -171,7 +171,7 @@ TypeSpecifier
 
 StructOrUnionSpecifier
    <- StructOrUnion
-      ( Identifier? LWING StructDeclaration+ RWING
+      ( Identifier? LWING StructDeclaration* RWING
       / Identifier
       )
 

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -82,6 +82,5 @@ func TestCParsing_Cast1(t *testing.T) {
 }
 
 func TestCParsing_Empty(t *testing.T) {
-	t.Skip() // this branch doesn't have the empty support yet.
 	parseC_4t(t, `/** empty is valid. */  `)
 }

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -108,3 +108,13 @@ int foo() {};;
 	noParseC_4t(t, `struct empty{}`)
 }
 
+func TestCParsing_Escapes(t *testing.T) {
+	parseC_4t(t, `
+int f() {
+	printf("%s", "\a\b\f\n\r\t\v");
+	printf("\\");
+	printf("\%");
+	printf("\"");
+	printf('\"'); // <- semantically wrong but syntactically valid.
+}`)
+}

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -84,3 +84,7 @@ func TestCParsing_Cast1(t *testing.T) {
 func TestCParsing_Empty(t *testing.T) {
 	parseC_4t(t, `/** empty is valid. */  `)
 }
+func TestCParsing_EmptyStruct(t *testing.T) {
+	parseC_4t(t, `struct empty{};`)
+}
+

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -96,6 +96,14 @@ func TestCParsing_EmptyStruct(t *testing.T) {
 	parseC_4t(t, `struct {} empty;`)
 	parseC_4t(t, `struct empty {} empty;`)
 }
+func TestCParsing_EmptyEmbeddedUnion(t *testing.T) {
+	parseC_4t(t, `struct empty{
+	union {
+		int a;
+		char b;
+	};
+};`)
+}
 func TestCParsing_ExtraSEMI(t *testing.T) {
 	parseC_4t(t, `int func(){}
 ;

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -19,6 +19,13 @@ func parseC_4t(t *testing.T, src string) *C {
 	return c
 }
 
+func noParseC_4t(t *testing.T, src string) {
+	_, err := parseCBuffer(src)
+	if err == nil {
+		t.Fatal("Parsed what should not have parsed.")
+	}
+}
+
 func TestCParsing_Expressions1(t *testing.T) {
 	case1src :=
 		`int a() {
@@ -88,5 +95,16 @@ func TestCParsing_EmptyStruct(t *testing.T) {
 	parseC_4t(t, `struct empty{};`)
 	parseC_4t(t, `struct {} empty;`)
 	parseC_4t(t, `struct empty {} empty;`)
+}
+func TestCParsing_ExtraSEMI(t *testing.T) {
+	parseC_4t(t, `int func(){}
+;
+struct {} empty;
+struct {} empty;;
+int foo() {};
+int foo() {};;
+`)
+
+	noParseC_4t(t, `struct empty{}`)
 }
 

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -86,5 +86,7 @@ func TestCParsing_Empty(t *testing.T) {
 }
 func TestCParsing_EmptyStruct(t *testing.T) {
 	parseC_4t(t, `struct empty{};`)
+	parseC_4t(t, `struct {} empty;`)
+	parseC_4t(t, `struct empty {} empty;`)
 }
 

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -107,6 +107,13 @@ int foo() {};;
 
 	noParseC_4t(t, `struct empty{}`)
 }
+func TestCParsing_ExtraSEMI2(t *testing.T) {
+	parseC_4t(t, `
+struct a { int b; ; };
+`)
+
+	noParseC_4t(t, `struct empty{}`)
+}
 
 func TestCParsing_Escapes(t *testing.T) {
 	parseC_4t(t, `
@@ -118,3 +125,4 @@ int f() {
 	printf('\"'); // <- semantically wrong but syntactically valid.
 }`)
 }
+


### PR DESCRIPTION
Bring in the ability to compile "common" (not "standard") C code by expanding the acceptable grammar to include common compiler extensions. This is the first part; "simple" changes that do not introduce any new keywords.