### PR TITLE
alphabetically emit imports and check for gofmt violations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,14 @@ clean:
 	rm -f bootstrap/bootstrap peg cmd/peg-bootstrap/{*peg.go,peg{[0-3],-bootstrap}}
 
 .PHONY:test
-test: peg
+test: peg fmt
 	go test
+
+.PHONY:fmt
+fmt:
+	# fail if any files don't match gofmt
+	gofmt -l -s {*,*/*,*/*/*}.go | awk ' { exit 1 } '
+
 
 .PHONY:bench
 bench:

--- a/grammars/c/grammar_test.go
+++ b/grammars/c/grammar_test.go
@@ -133,4 +133,3 @@ int f() {
 	printf('\"'); // <- semantically wrong but syntactically valid.
 }`)
 }
-

--- a/grammars/c/main.go
+++ b/grammars/c/main.go
@@ -25,7 +25,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		if fileInfo.Mode() & (os.ModeNamedPipe | os.ModeSocket | os.ModeDevice) != 0 {
+		if fileInfo.Mode()&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
 			/* will lock up if opened */
 		} else if fileInfo.IsDir() {
 			fmt.Printf("directory %v\n", name)

--- a/grammars/java/main.go
+++ b/grammars/java/main.go
@@ -25,7 +25,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		if fileInfo.Mode() & (os.ModeNamedPipe | os.ModeSocket | os.ModeDevice) != 0 {
+		if fileInfo.Mode()&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
 			/* will lock up if opened */
 		} else if fileInfo.IsDir() {
 			fmt.Printf("directory %v\n", name)

--- a/peg.peg.go
+++ b/peg.peg.go
@@ -3,8 +3,8 @@ package main
 //go:generate peg -inline -switch peg.peg
 
 import (
-	"github.com/pointlander/peg/tree"
 	"fmt"
+	"github.com/pointlander/peg/tree"
 	"math"
 	"sort"
 	"strconv"

--- a/tree/peg.go
+++ b/tree/peg.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"math"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"text/template"
@@ -817,6 +818,9 @@ func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 				}
 			}
 		}
+		/* sort imports to satisfy gofmt */
+		sort.Strings(t.Imports)
+
 		/* second pass */
 		for _, node := range t.Slice() {
 			if node.GetType() == TypeRule {
@@ -1061,7 +1065,7 @@ func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 			}
 		}
 
-		for i, _ := range cache {
+		for i := range cache {
 			cache[i].reached = false
 		}
 		firstPass = false


### PR DESCRIPTION
gofmt expects alphabetized imports, so sort the import list. Also
includes a 'fmt' makefile rule to check the code against gofmt.