### PR TITLE
add WriteSyntaxTree to generated parser API

### DIFF
--- a/tree/peg.go
+++ b/tree/peg.go
@@ -243,6 +243,11 @@ func (p *{{.StructName}}) PrintSyntaxTree() {
 	}
 }
 
+func (p *{{.StructName}}) WriteSyntaxTree(w io.Writer) {
+	p.tokens32.WriteSyntaxTree(w, p.Buffer)
+}
+
+
 {{if .HasActions}}
 func (p *{{.StructName}}) Execute() {
 	buffer, _buffer, text, begin, end := p.Buffer, p.buffer, "", 0, 0

--- a/tree/peg.go
+++ b/tree/peg.go
@@ -62,7 +62,7 @@ type node32 struct {
 	up, next *node32
 }
 
-func (node *node32) print(pretty bool, buffer string) {
+func (node *node32) print(w io.Writer, pretty bool, buffer string) {
 	var print func(node *node32, depth int)
 	print = func(node *node32, depth int) {
 		for node != nil {
@@ -72,9 +72,9 @@ func (node *node32) print(pretty bool, buffer string) {
 			rule := rul3s[node.pegRule]
 			quote := strconv.Quote(string(([]rune(buffer)[node.begin:node.end])))
 			if !pretty {
-				fmt.Printf("%v %v\n", rule, quote)
+				fmt.Fprintf(w, "%v %v\n", rule, quote)
 			} else {
-				fmt.Printf("\x1B[34m%v\x1B[m %v\n", rule, quote)
+				fmt.Fprintf(w, "\x1B[34m%v\x1B[m %v\n", rule, quote)
 			}
 			if node.up != nil {
 				print(node.up, depth + 1)
@@ -85,12 +85,12 @@ func (node *node32) print(pretty bool, buffer string) {
 	print(node, 0)
 }
 
-func (node *node32) Print(buffer string) {
-	node.print(false, buffer)
+func (node *node32) Print(w io.Writer, buffer string) {
+	node.print(w, false, buffer)
 }
 
-func (node *node32) PrettyPrint(buffer string) {
-	node.print(true, buffer)
+func (node *node32) PrettyPrint(w io.Writer, buffer string) {
+	node.print(w, true, buffer)
 }
 
 type tokens32 struct {
@@ -133,11 +133,15 @@ func (t *tokens32) AST() *node32 {
 }
 
 func (t *tokens32) PrintSyntaxTree(buffer string) {
-	t.AST().Print(buffer)
+	t.AST().Print(os.Stdout, buffer)
+}
+
+func (t *tokens32) WriteSyntaxTree(w io.Writer, buffer string) {
+	t.AST().Print(w, buffer)
 }
 
 func (t *tokens32) PrettyPrintSyntaxTree(buffer string) {
-	t.AST().PrettyPrint(buffer)
+	t.AST().PrettyPrint(os.Stdout, buffer)
 }
 
 func (t *tokens32) Add(rule pegRule, begin, end, index uint32) {
@@ -711,9 +715,11 @@ func escape(c string) string {
 
 func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 	t.AddImport("fmt")
+	t.AddImport("io")
 	if t.Ast {
 		t.AddImport("math")
 	}
+	t.AddImport("os")
 	t.AddImport("sort")
 	t.AddImport("strconv")
 	t.EndSymbol = 0x110000


### PR DESCRIPTION
Adds a method to generated parsers called `WriteSyntaxTree` that accepts an `io.Writer` the caller supplies. Really handy for logging the AST from a parse.

Thank you for the library!