### PR TITLE
Allow digits in imported package names

### DIFF
--- a/peg.peg
+++ b/peg.peg
@@ -29,7 +29,7 @@ Import		<- 'import' Spacing (MultiImport / SingleImport) Spacing
 SingleImport	<- ImportName 
 MultiImport	<- '(' Spacing (ImportName '\n' Spacing)* Spacing ')' 
 
-ImportName	<- ["] < [a-zA-Z_/.\-]+ > ["]	{ p.AddImport(text) }
+ImportName	<- ["] < [0-9a-zA-Z_/.\-]+ > ["]	{ p.AddImport(text) }
 
 Definition	<- Identifier 			{ p.AddRule(text) }
 		     LeftArrow Expression 	{ p.AddExpression() } &(Identifier LeftArrow / !.)

--- a/peg.peg.go
+++ b/peg.peg.go
@@ -929,7 +929,7 @@ func (p *Peg) Init(options ...func(*Peg) error) error {
 		nil,
 		/* 3 MultiImport <- <('(' Spacing (ImportName '\n' Spacing)* Spacing ')')> */
 		nil,
-		/* 4 ImportName <- <('"' <((&('-') '-') | (&('.') '.') | (&('/') '/') | (&('_') '_') | (&('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z') [A-Z]) | (&('a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z') [a-z]))+> '"' Action3)> */
+		/* 4 ImportName <- <('"' <((&('-') '-') | (&('.') '.') | (&('/') '/') | (&('_') '_') | (&('A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G' | 'H' | 'I' | 'J' | 'K' | 'L' | 'M' | 'N' | 'O' | 'P' | 'Q' | 'R' | 'S' | 'T' | 'U' | 'V' | 'W' | 'X' | 'Y' | 'Z') [A-Z]) | (&('0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9') [0-9]) | (&('a' | 'b' | 'c' | 'd' | 'e' | 'f' | 'g' | 'h' | 'i' | 'j' | 'k' | 'l' | 'm' | 'n' | 'o' | 'p' | 'q' | 'r' | 's' | 't' | 'u' | 'v' | 'w' | 'x' | 'y' | 'z') [a-z]))+> '"' Action3)> */
 		func() bool {
 			position35, tokenIndex35 := position, tokenIndex
 			{
@@ -964,6 +964,11 @@ func (p *Peg) Init(options ...func(*Peg) error) error {
 							position++
 						case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z':
 							if c := buffer[position]; c < rune('A') || c > rune('Z') {
+								goto l35
+							}
+							position++
+						case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+							if c := buffer[position]; c < rune('0') || c > rune('9') {
 								goto l35
 							}
 							position++
@@ -1002,6 +1007,11 @@ func (p *Peg) Init(options ...func(*Peg) error) error {
 								position++
 							case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z':
 								if c := buffer[position]; c < rune('A') || c > rune('Z') {
+									goto l39
+								}
+								position++
+							case '0', '1', '2', '3', '4', '5', '6', '7', '8', '9':
+								if c := buffer[position]; c < rune('0') || c > rune('9') {
 									goto l39
 								}
 								position++


### PR DESCRIPTION
Go package imports can contain digits. In the present implementation any such import is rejected as a parsing error. I simply added `0-9` to the allowable characters for an ImportName to fix this.

The astute may note that my own profile name contains a digit, and therefore without this change none of my own packages can be imported into a grammar file.

Seriously though smallest change ever, all tests are still passed, and I can't think of any way this could cause any sort of problem.