### PR TITLE
fix c grammar for wide string literals

### DIFF
--- a/grammars/c/c.peg
+++ b/grammars/c/c.peg
@@ -313,9 +313,9 @@ JumpStatement
 #-------------------------------------------------------------------------
 
 PrimaryExpression
-   <- Identifier
+   <- StringLiteral
     / Constant
-    / StringLiteral
+    / Identifier
     / LPAR Expression RPAR
 
 PostfixExpression

--- a/grammars/c/c_test.go
+++ b/grammars/c/c_test.go
@@ -202,3 +202,7 @@ func TestCParsing_Long(t *testing.T) {
 	}
 	walk("c/")
 }
+
+func TestCParsing_WideString(t *testing.T) {
+	parseC_4t(t, `wchar_t *msg = L"Hello";`);
+}


### PR DESCRIPTION
Fixes https://github.com/pointlander/peg/issues/121 (c.peg cannot parse wide-string literals).

The issue appears to be that the `L` prefix will be captured by the `Identifier` subrule in `PrimaryExpression` before `StringLiteral` can capture it.  My fix is to reorder these subrules, putting `StringLiteral` before `Identifier`.