### PR TITLE
fix: add strings

### DIFF
--- a/tree/peg.go
+++ b/tree/peg.go
@@ -829,6 +829,7 @@ func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 	}
 	t.AddImport("sort")
 	t.AddImport("strconv")
+	t.AddImport("strings")
 	t.EndSymbol = 0x110000
 	t.RulesCount++
 


### PR DESCRIPTION
When peg generate code like this:

```go
		case ruleAction63:
			p.Search.Operand(&search.NodeBcc{}, strings.Trim(text, `"`))
```

peg dont add strings import