### PR TITLE
Make executable name static in generated code

### DIFF
--- a/tree/peg.go
+++ b/tree/peg.go
@@ -833,7 +833,7 @@ func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 	t.EndSymbol = 0x110000
 	t.RulesCount++
 
-	t.Generator = strings.Join(args, " ")
+	t.Generator = strings.Join(append([]string{"peg"}, args[1:]...), " ")
 
 	var werr error
 	warn := func(e error) {


### PR DESCRIPTION
When using peg via `go run` the executable name is a path that changes every invocation. This PR hardcodes the first argument to `peg` so that subsequent runs of `go run` always generate the same output file.

Before
```
// Code generated by /var/folders/w2/fb613tqx6rzftr9k0v_pcfmr0000gn/T/go-build1383365192/b001/exe/peg grammar.peg DO NOT EDIT.
```
After
```
// Code generated by peg grammar.peg DO NOT EDIT.
```