### PR TITLE
Remove broken link to GitHub project

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,5 +243,4 @@ Andrew Snodgrass
 Here are some projects that use `peg` to provide further examples of PEG grammars:
 
 * https://github.com/tj/go-naturaldate - natural date/time parsing
-* https://github.com/robmuh/dtime - easy date/time formats with duration spans
 * https://github.com/gnames/gnparser - scientific names parsing


### PR DESCRIPTION
* Looks like GitHub user github.com/robmuh is now known as github.com/rwxrob but the dtime repository is no longer among his public repositories.