### PR TITLE
bootstrap.bash: fix initial cleanup

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 
 
-(cd bootstrap && go build && rm -f bootstrap/bootstrap.peg.go)
+(cd bootstrap && go build && rm -f bootstrap.peg.go)
 
 
 cd cmd/peg-bootstrap


### PR DESCRIPTION
Fixes this failure on macOS:
```console
$ ./bootstrap.bash
rm: bootstrap/bootstrap.peg.go: Not a directory
```

## Why?

On macOS, `rm -f` is stricter about its given paths: `rm -f a/b` fails if `a` is not a directory but a file.

With the command `(cd bootstrap && go build && rm -f bootstrap/bootstrap.peg.go)` we try to remove `bootstrap/bootstrap/bootstrap.peg.go` while we just created `bootstrap/bootstrap` as a file, not a directory.