### PR TITLE
chores: refactor internal build to call peg via "go tool"

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -36,5 +36,4 @@ rm -f peg-bootstrap.peg.go
 # Build peg
 cd ../..
 ./cmd/peg-bootstrap/peg-bootstrap < peg.peg > peg.peg.go
-go build
-./peg -inline -switch peg.peg
+go tool peg -inline -switch peg.peg

--- a/generate-grammars.bash
+++ b/generate-grammars.bash
@@ -1,10 +1,3 @@
 #!/bin/bash
 
-set -Eeuo pipefail
-
-(cd grammars/c/ && go generate)
-(cd grammars/calculator/ && go generate)
-(cd grammars/calculatorast/ && go generate)
-(cd grammars/fexl/ && go generate)
-(cd grammars/java/ && go generate)
-(cd grammars/longtest/ && go generate)
+exec go generate "$@" ./grammars/...

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/pointlander/peg
 
 go 1.25
+
+tool github.com/pointlander/peg

--- a/grammars/c/c_test.go
+++ b/grammars/c/c_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline c.peg
+//go:generate go tool peg -switch -inline c.peg
 
 package c
 

--- a/grammars/calculator/calculator_test.go
+++ b/grammars/calculator/calculator_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline calculator.peg
+//go:generate go tool peg -switch -inline calculator.peg
 
 package calculator
 

--- a/grammars/calculatorast/calculator_test.go
+++ b/grammars/calculatorast/calculator_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline calculator.peg
+//go:generate go tool peg -switch -inline calculator.peg
 
 package calculatorast
 

--- a/grammars/fexl/fexl_test.go
+++ b/grammars/fexl/fexl_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline fexl.peg
+//go:generate go tool peg -switch -inline fexl.peg
 
 package fexl
 

--- a/grammars/java/java_test.go
+++ b/grammars/java/java_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline java_1_7.peg
+//go:generate go tool peg -switch -inline java_1_7.peg
 
 package java
 

--- a/grammars/longtest/long_test.go
+++ b/grammars/longtest/long_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate ../../peg -switch -inline long.peg
+//go:generate go tool peg -switch -inline long.peg
 
 package longtest
 


### PR DESCRIPTION
* Add `peg` as a [tool](https://go.dev/doc/modules/gomod-ref#tool): `go get -tool .`
* Update `//go:generate` lines in `grammars/`, and `generate-grammars.bash`, `bootstrap.bash` to now execute `peg` via `go tool peg`

Benefits:
* use modern features of the Go toolchain, towards more portability (to be even more contributor friendly)
* running the `peg` tool via `go tool` ensures a fresh build from the latest local sources
* shows the way for users how to use `peg` with a modern toolchain (go1.24+)