### PR TITLE
bootstrap: catch errors early and fail

### DIFF
--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -5,13 +5,15 @@
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 
 	"github.com/pointlander/peg/tree"
 )
 
 func main() {
+	log.SetFlags(0)
+
 	t := tree.New(true, true, false)
 
 	/*package main
@@ -530,14 +532,17 @@ func main() {
 	filename := "bootstrap.peg.go"
 	out, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
-		fmt.Printf("%v: %v\n", filename, err)
+		log.Fatalf("%v: %v\n", filename, err)
 		return
 	}
 	defer func() {
 		err := out.Close()
 		if err != nil {
-			fmt.Printf("%v: %v\n", filename, err)
+			log.Fatalf("%v: %v\n", filename, err)
 		}
 	}()
-	_ = t.Compile(filename, os.Args, out)
+	err = t.Compile(filename, os.Args, out)
+	if err != nil {
+		log.Fatalf("%s: %v", filename, err)
+	}
 }

--- a/cmd/peg-bootstrap/main.go
+++ b/cmd/peg-bootstrap/main.go
@@ -16,15 +16,21 @@ import (
 )
 
 func main() {
+	log.SetFlags(0)
+
 	buffer, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatal(err)
 	}
 	p := &Peg[uint32]{Tree: tree.New(false, false, false), Buffer: string(buffer)}
-	p.Init(Pretty[uint32](true), Size[uint32](1<<15))
+	if err := p.Init(Pretty[uint32](true), Size[uint32](1<<15)); err != nil {
+		log.Fatal("Init:", err)
+	}
 	if err := p.Parse(); err != nil {
-		log.Fatal(err)
+		log.Fatal("Parse:", err)
 	}
 	p.Execute()
-	p.Compile("boot.peg.go", os.Args, os.Stdout)
+	if err := p.Compile("boot.peg.go", os.Args, os.Stdout); err != nil {
+		log.Fatal("Compile:", err)
+	}
 }


### PR DESCRIPTION
To ease debugging the bootstrap process, catch errors early and fail with exit code.

For example, this allows to catch mistakes made when modifying `tree/peg.go.tmpl`.