### PR TITLE
grammars: generate in strict mode (peg -strict)

### DIFF
--- a/grammars/c/c_test.go
+++ b/grammars/c/c_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline c.peg
+//go:generate go tool peg -strict -switch -inline c.peg
 
 package c
 

--- a/grammars/calculator/calculator_test.go
+++ b/grammars/calculator/calculator_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline calculator.peg
+//go:generate go tool peg -strict -switch -inline calculator.peg
 
 package calculator
 

--- a/grammars/calculatorast/calculator_test.go
+++ b/grammars/calculatorast/calculator_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline calculator.peg
+//go:generate go tool peg -strict -switch -inline calculator.peg
 
 package calculatorast
 

--- a/grammars/fexl/fexl_test.go
+++ b/grammars/fexl/fexl_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline fexl.peg
+//go:generate go tool peg -strict -switch -inline fexl.peg
 
 package fexl
 

--- a/grammars/java/java_test.go
+++ b/grammars/java/java_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline java_1_7.peg
+//go:generate go tool peg -strict -switch -inline java_1_7.peg
 
 package java
 

--- a/grammars/longtest/long_test.go
+++ b/grammars/longtest/long_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go tool peg -switch -inline long.peg
+//go:generate go tool peg -strict -switch -inline long.peg
 
 package longtest
 


### PR DESCRIPTION
Change the '//go:generate' in grammars/... to use -strict mode.

```console
$ go generate -x ./grammars/...
go tool peg -strict -switch -inline c.peg
go tool peg -strict -switch -inline calculator.peg
go tool peg -strict -switch -inline calculator.peg
go tool peg -strict -switch -inline fexl.peg
go tool peg -strict -switch -inline java_1_7.peg
go tool peg -strict -switch -inline long.peg
```