### PR TITLE
Refactor bootstrap.bash to improve readability of the bootstrap steps

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -3,37 +3,29 @@
 set -Eeuo pipefail
 
 
-(cd bootstrap && go build && rm -f bootstrap.peg.go)
+# Clean the file produced by ./bootstrap
+rm -f bootstrap/bootstrap.peg.go
 
 
 cd cmd/peg-bootstrap
 
-# Build peg0
-./../../bootstrap/bootstrap
-go build -tags bootstrap -o peg0
-rm -f bootstrap.peg.go
+# Remove artefacts from a previous incomplete build
+rm -f bootstrap.peg.go peg[123].peg.go peg-bootstrap.peg.go
+# Remove binaries produced by previous versions of the build
+rm -f peg[0123] peg-bootstrap
 
-# Build peg1
-./peg0 < bootstrap.peg > peg1.peg.go
-go build -tags bootstrap -o peg1
-rm -f peg1.peg.go
+go run ../../bootstrap
+go run -tags bootstrap  main.go bootstrap.peg.go     < bootstrap.peg     > peg1.peg.go
+go run -tags bootstrap  main.go peg1.peg.go          < peg.bootstrap.peg > peg2.peg.go
+go run -tags bootstrap  main.go peg2.peg.go          < ../../peg.peg     > peg3.peg.go
+go run -tags bootstrap  main.go peg3.peg.go          < ../../peg.peg     > peg-bootstrap.peg.go
+go run -tags bootstrap  main.go peg-bootstrap.peg.go < ../../peg.peg     > ../../peg.peg.go
 
-# Build peg2
-./peg1 < peg.bootstrap.peg > peg2.peg.go
-go build -tags bootstrap -o peg2
-rm -f peg2.peg.go
+# Remove artefacts from the build
+rm -f bootstrap.peg.go peg[123].peg.go peg-bootstrap.peg.go
 
-# Build peg3
-./peg2 < ../../peg.peg > peg3.peg.go
-go build -tags bootstrap -o peg3
-rm -f peg3.peg.go
-
-# Build peg-bootstrap
-./peg3 < ../../peg.peg > peg-bootstrap.peg.go
-go build -tags bootstrap -o peg-bootstrap
-rm -f peg-bootstrap.peg.go
-
-# Build peg
+# Final rebuild
 cd ../..
-./cmd/peg-bootstrap/peg-bootstrap < peg.peg > peg.peg.go
 go tool peg -inline -switch peg.peg
+
+


### PR DESCRIPTION
Refactor `bootstrap.bash`:
1. Use "go run" to execute each step: this allows to build, run, and cleanup the binary in a single line
2. Make each step a single command with an explicit list of source files which are part of the build, and aligned input and output files: this improves readibility
3. Cleanup intermediate files in case of success.
4. As the previous build script was leaving artefacts, add cleanup of those obsolete artefacts as they are no longer relevant and could be misleading.

Extract of the final script:
```sh
go run ../../bootstrap
go run -tags bootstrap  main.go bootstrap.peg.go     < bootstrap.peg     > peg1.peg.go
go run -tags bootstrap  main.go peg1.peg.go          < peg.bootstrap.peg > peg2.peg.go
go run -tags bootstrap  main.go peg2.peg.go          < ../../peg.peg     > peg3.peg.go
go run -tags bootstrap  main.go peg3.peg.go          < ../../peg.peg     > peg-bootstrap.peg.go
go run -tags bootstrap  main.go peg-bootstrap.peg.go < ../../peg.peg     > ../../peg.peg.go
```

Note: next refactor step should about refactoring ./bootstrap/main.go to make its output more explicit.