### PR TITLE
bootstrap: refactor bootstrap tool for output on stdout

### DIFF
--- a/bootstrap.bash
+++ b/bootstrap.bash
@@ -10,19 +10,19 @@ rm -f bootstrap/bootstrap.peg.go
 cd cmd/peg-bootstrap
 
 # Remove artefacts from a previous incomplete build
-rm -f bootstrap.peg.go peg[123].peg.go peg-bootstrap.peg.go
-# Remove binaries produced by previous versions of the build
-rm -f peg[0123] peg-bootstrap
+rm -f peg[0123].peg.go peg-bootstrap.peg.go
+# Remove files produced by previous versions of the build
+rm -f peg[0123] peg-bootstrap bootstrap.peg.go
 
-go run ../../bootstrap
-go run -tags bootstrap  main.go bootstrap.peg.go     < bootstrap.peg     > peg1.peg.go
+go run ../../bootstrap                                                   > peg0.peg.go
+go run -tags bootstrap  main.go peg0.peg.go          < bootstrap.peg     > peg1.peg.go
 go run -tags bootstrap  main.go peg1.peg.go          < peg.bootstrap.peg > peg2.peg.go
 go run -tags bootstrap  main.go peg2.peg.go          < ../../peg.peg     > peg3.peg.go
 go run -tags bootstrap  main.go peg3.peg.go          < ../../peg.peg     > peg-bootstrap.peg.go
 go run -tags bootstrap  main.go peg-bootstrap.peg.go < ../../peg.peg     > ../../peg.peg.go
 
 # Remove artefacts from the build
-rm -f bootstrap.peg.go peg[123].peg.go peg-bootstrap.peg.go
+rm -f peg[0123].peg.go peg-bootstrap.peg.go
 
 # Final rebuild
 cd ../..

--- a/bootstrap/main.go
+++ b/bootstrap/main.go
@@ -5,15 +5,13 @@
 package main
 
 import (
-	"log"
+	"fmt"
 	"os"
 
 	"github.com/pointlander/peg/tree"
 )
 
 func main() {
-	log.SetFlags(0)
-
 	t := tree.New(true, true, false)
 
 	/*package main
@@ -529,20 +527,9 @@ func main() {
 		)
 	})
 
-	filename := "bootstrap.peg.go"
-	out, err := os.OpenFile(filename, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0o644)
+	err := t.Compile("", os.Args, os.Stdout)
 	if err != nil {
-		log.Fatalf("%v: %v\n", filename, err)
-		return
-	}
-	defer func() {
-		err := out.Close()
-		if err != nil {
-			log.Fatalf("%v: %v\n", filename, err)
-		}
-	}()
-	err = t.Compile(filename, os.Args, out)
-	if err != nil {
-		log.Fatalf("%s: %v", filename, err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Refactor bootstrap to make command ./bootstrap (package github.com/pointlander/peg/bootstrap) to output to stdout instead of a hardcoded output file.

This allows the source of the bootstrap.bash script to show more clearly the various steps and the intermediate files produced and consumed during bootstrap.