### PR TITLE
tree.Compile: gofmt with parser.SkipObjectResolution

### DIFF
--- a/tree/peg.go
+++ b/tree/peg.go
@@ -1334,7 +1334,7 @@ func (t *Tree) Compile(file string, args []string, out io.Writer) (err error) {
 		return err
 	}
 	fileSet := token.NewFileSet()
-	code, err := parser.ParseFile(fileSet, file, &buffer, parser.ParseComments)
+	code, err := parser.ParseFile(fileSet, file, &buffer, parser.ParseComments|parser.SkipObjectResolution)
 	if err != nil {
 		_, _ = buffer.WriteTo(out)
 		return err


### PR DESCRIPTION
In [`tree.Compile`](https://pkg.go.dev/github.com/pointlander/peg/tree#Compile), at the final step that process the generated source with [`go/parser`](https://pkg.go.dev/go/parser) and [`go/printer`](https://pkg.go.dev/go/printer) to kinda gofmt it, parse with flag [`SkipObjectResolution`](https://pkg.go.dev/go/parser#SkipObjectResolution). Object resolution is deprecated since the generics era (`go/types` must be used). This flag allows to save resources (cpu, memory) by not doing work we don't use.